### PR TITLE
Specify branch name for the fake repo

### DIFF
--- a/R/fake_repo.R
+++ b/R/fake_repo.R
@@ -19,7 +19,7 @@
 
 fake_repo <- function(path = tempfile(pattern = "git2r-"), as.package = FALSE) {
   if (!dir.exists(path)) {dir.create(path)}
-  repo <- init(path, branch = "master")
+  repo <- init(path)
 
   ## Config user
   config(repo, user.name = "Alice", user.email = "alice@example.org")
@@ -92,6 +92,8 @@ fake_repo <- function(path = tempfile(pattern = "git2r-"), as.package = FALSE) {
     # Create a vignette directory
     dir.create(file.path(path, "vignettes"))
   }
+
+  git2r::checkout(repo, branch = "main", create = TRUE)
 
   return(path)
 }

--- a/R/fake_repo.R
+++ b/R/fake_repo.R
@@ -19,7 +19,7 @@
 
 fake_repo <- function(path = tempfile(pattern = "git2r-"), as.package = FALSE) {
   if (!dir.exists(path)) {dir.create(path)}
-  repo <- init(path)
+  repo <- init(path, branch = "master")
 
   ## Config user
   config(repo, user.name = "Alice", user.email = "alice@example.org")

--- a/R/get_commits.R
+++ b/R/get_commits.R
@@ -25,9 +25,9 @@
 #' @examples
 #' repo <- fake_repo()
 #' get_commits_tags(repo = repo)
-get_commits_tags <- function(repo = ".", ref = "master",
+get_commits_tags <- function(repo = ".", ref = "main",
                              path = NULL, silent = FALSE) {
-  # checkout(repo, "master")
+  # checkout(repo, "main")
   # Get commits
   all_commits <- commits(
     repo = repo, ref = ref,
@@ -108,7 +108,7 @@ get_commits_tags <- function(repo = ".", ref = "master",
 
 get_commits_pattern <- function(repo = ".", pattern = c("Ticket" = "#[[:digit:]]+"),
                                 pattern.table = NULL,
-                                ref = "master", path = NULL, silent = FALSE) {
+                                ref = "main", path = NULL, silent = FALSE) {
 
   if (is.null(names(pattern))) {names(pattern) <- paste0("`", pattern, "`")}
 

--- a/R/git_down.R
+++ b/R/git_down.R
@@ -9,7 +9,7 @@
 #' @param book_path The path to the bookdown output. Default is `"gitdown"`.
 #' @param open Should the bookdown be opened once compiled? Default is TRUE.
 #' @param author Author of the bookdown
-#' @param ref the name of the branch, by default master
+#' @param ref the name of the branch, by default main
 #' @param ... Other parameters to pass to [rmarkdown::render()]
 #'
 #' @inheritParams get_commits_pattern
@@ -51,7 +51,7 @@ git_down <- function(repo = ".", book_path = "gitdown",
                      open = TRUE, author = "John Doe",
                      pattern = c("Issues" = "#[[:digit:]]+"),
                      pattern.table = NULL,
-                     ref = "master", ...) {
+                     ref = "main", ...) {
 
   # Clean previous book
   unlink(file.path(repo, book_path), recursive = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -134,7 +134,7 @@ to_singular <- function(x) {
 nest_commits_by_pattern <- function(repo,
                                     pattern = c("Issues" = "#[[:digit:]]+"),
                                     pattern.table = NULL,
-                                    ref = "master", silent = TRUE) {
+                                    ref = "main", silent = TRUE) {
 
   res <- get_commits_pattern(repo, pattern = pattern,
                              pattern.table = pattern.table,
@@ -211,7 +211,7 @@ nest_commits_by_pattern <- function(repo,
 #' res_commits <- nest_commits_by_pattern(
 #'   repo,
 #'   pattern = c("Tickets" = "ticket[[:digit:]]+"),
-#'   ref = "master", silent = TRUE
+#'   ref = "main", silent = TRUE
 #' )
 #' each_pattern(res_commits, "Tickets")
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -25,7 +25,7 @@ file.copy(list.files("reference/figures", full.names = TRUE),
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/ThinkR-open/gitdown/workflows/R-CMD-check/badge.svg)](https://github.com/ThinkR-open/gitdown/actions)
-[![Coverage status](https://codecov.io/gh/ThinkR-open/gitdown/branch/master/graph/badge.svg)](https://codecov.io/github/ThinkR-open/gitdown?branch=master)
+[![Coverage status](https://codecov.io/gh/ThinkR-open/gitdown/branch/main/graph/badge.svg)](https://codecov.io/github/ThinkR-open/gitdown?branch=main)
 [![CRAN status](https://www.r-pkg.org/badges/version/gitdown)](https://CRAN.R-project.org/package=gitdown)
 <!-- badges: end -->
 
@@ -106,7 +106,7 @@ As a side effect of {gitdown}, you can get some intermediate information used to
 Get commits with issues mentioned. The searched pattern is a `#` followed by at least one number: `"#[[:digit:]]+"`. Variable `pattern.content` lists patterns found in the commit messages. 
 
 ```{r}
-get_commits_pattern(repo, pattern = "#[[:digit:]]+", ref = "master") %>% 
+get_commits_pattern(repo, pattern = "#[[:digit:]]+", ref = "main") %>% 
   select(pattern.content, everything())
 ```
 
@@ -116,7 +116,7 @@ Get commits with issues and specific home-made pattern. Use a named vector to pr
 get_commits_pattern(
   repo, 
   pattern =  c("Tickets" = "ticket[[:digit:]]+", "Issues" = "#[[:digit:]]+"),
-  ref = "master"
+  ref = "main"
 ) %>% 
   select(pattern.type, pattern.content, everything())
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![R-CMD-check](https://github.com/ThinkR-open/gitdown/workflows/R-CMD-check/badge.svg)](https://github.com/ThinkR-open/gitdown/actions)
 [![Coverage
-status](https://codecov.io/gh/ThinkR-open/gitdown/branch/master/graph/badge.svg)](https://codecov.io/github/ThinkR-open/gitdown?branch=master)
+status](https://codecov.io/gh/ThinkR-open/gitdown/branch/main/graph/badge.svg)](https://codecov.io/github/ThinkR-open/gitdown?branch=main)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/gitdown)](https://CRAN.R-project.org/package=gitdown)
 <!-- badges: end -->
@@ -105,19 +105,19 @@ followed by at least one number: `"#[[:digit:]]+"`. Variable
 `pattern.content` lists patterns found in the commit messages.
 
 ``` r
-get_commits_pattern(repo, pattern = "#[[:digit:]]+", ref = "master") %>% 
+get_commits_pattern(repo, pattern = "#[[:digit:]]+", ref = "main") %>% 
   select(pattern.content, everything())
 #> 4 commits found.
-#> # A tibble: 7 x 12
+#> # A tibble: 7 × 12
 #>   pattern.content sha    summary message  author email when                order
 #>   <chr>           <chr>  <chr>   <chr>    <chr>  <chr> <dttm>              <int>
-#> 1 #32             86ec5… Add NE… "Add NE… Alice  alic… 2021-05-10 14:03:56     4
-#> 2 #1              86ec5… Add NE… "Add NE… Alice  alic… 2021-05-10 14:03:56     4
-#> 3 #12             86ec5… Add NE… "Add NE… Alice  alic… 2021-05-10 14:03:56     4
-#> 4 #2              5e338… Third … "Third … Alice  alic… 2021-05-10 14:03:56     3
-#> 5 #145            5e338… Third … "Third … Alice  alic… 2021-05-10 14:03:56     3
-#> 6 #1              cefcf… exampl… "exampl… Alice  alic… 2021-05-10 14:03:56     2
-#> 7 <NA>            f50e2… First … "First … Alice  alic… 2021-05-10 14:03:56     1
+#> 1 #32             8790c… Add NE… "Add NE… Alice  alic… 2022-03-04 15:31:14     4
+#> 2 #1              8790c… Add NE… "Add NE… Alice  alic… 2022-03-04 15:31:14     4
+#> 3 #12             8790c… Add NE… "Add NE… Alice  alic… 2022-03-04 15:31:14     4
+#> 4 #2              c0870… Third … "Third … Alice  alic… 2022-03-04 15:31:14     3
+#> 5 #145            c0870… Third … "Third … Alice  alic… 2022-03-04 15:31:14     3
+#> 6 #1              a97db… exampl… "exampl… Alice  alic… 2022-03-04 15:31:14     2
+#> 7 <NA>            b27b5… First … "First … Alice  alic… 2022-03-04 15:31:14     1
 #> # … with 4 more variables: tag.name <chr>, tag.message <chr>,
 #> #   pattern.type <chr>, pattern.title <chr>
 ```
@@ -129,25 +129,25 @@ vector to properly separate types of patterns.
 get_commits_pattern(
   repo, 
   pattern =  c("Tickets" = "ticket[[:digit:]]+", "Issues" = "#[[:digit:]]+"),
-  ref = "master"
+  ref = "main"
 ) %>% 
   select(pattern.type, pattern.content, everything())
 #> 4 commits found.
-#> # A tibble: 12 x 12
+#> # A tibble: 12 × 12
 #>    pattern.type pattern.content sha       summary   message        author email 
 #>    <chr>        <chr>           <chr>     <chr>     <chr>          <chr>  <chr> 
-#>  1 Tickets      ticket6789      86ec55cd… Add NEWS  "Add NEWS\n\n… Alice  alice…
-#>  2 Tickets      ticket1234      86ec55cd… Add NEWS  "Add NEWS\n\n… Alice  alice…
-#>  3 Issues       #32             86ec55cd… Add NEWS  "Add NEWS\n\n… Alice  alice…
-#>  4 Issues       #1              86ec55cd… Add NEWS  "Add NEWS\n\n… Alice  alice…
-#>  5 Issues       #12             86ec55cd… Add NEWS  "Add NEWS\n\n… Alice  alice…
-#>  6 Tickets      <NA>            5e338c4c… Third co… "Third commit… Alice  alice…
-#>  7 Issues       #2              5e338c4c… Third co… "Third commit… Alice  alice…
-#>  8 Issues       #145            5e338c4c… Third co… "Third commit… Alice  alice…
-#>  9 Tickets      ticket1234      cefcfbb7… example:… "example: mod… Alice  alice…
-#> 10 Issues       #1              cefcfbb7… example:… "example: mod… Alice  alice…
-#> 11 Tickets      <NA>            f50e27f9… First co… "First commit… Alice  alice…
-#> 12 Issues       <NA>            f50e27f9… First co… "First commit… Alice  alice…
+#>  1 Tickets      ticket6789      8790cc60… Add NEWS  "Add NEWS\n\n… Alice  alice…
+#>  2 Tickets      ticket1234      8790cc60… Add NEWS  "Add NEWS\n\n… Alice  alice…
+#>  3 Issues       #32             8790cc60… Add NEWS  "Add NEWS\n\n… Alice  alice…
+#>  4 Issues       #1              8790cc60… Add NEWS  "Add NEWS\n\n… Alice  alice…
+#>  5 Issues       #12             8790cc60… Add NEWS  "Add NEWS\n\n… Alice  alice…
+#>  6 Tickets      <NA>            c0870ab4… Third co… "Third commit… Alice  alice…
+#>  7 Issues       #2              c0870ab4… Third co… "Third commit… Alice  alice…
+#>  8 Issues       #145            c0870ab4… Third co… "Third commit… Alice  alice…
+#>  9 Tickets      ticket1234      a97db45b… example:… "example: mod… Alice  alice…
+#> 10 Issues       #1              a97db45b… example:… "example: mod… Alice  alice…
+#> 11 Tickets      <NA>            b27b55fe… First co… "First commit… Alice  alice…
+#> 12 Issues       <NA>            b27b55fe… First co… "First commit… Alice  alice…
 #> # … with 5 more variables: when <dttm>, order <int>, tag.name <chr>,
 #> #   tag.message <chr>, pattern.title <chr>
 ```
@@ -164,11 +164,11 @@ create_vignette_last_modif(repo_pkg, path = "")
 
 With this example, the vignette will show this content:
 
-| File         | Tracked in git | Date of creation    | Last modification   |
-|:-------------|:---------------|:--------------------|:--------------------|
-| NEWS.md      | Yes            | 2021-05-10 16:03:56 | 2021-05-10 16:03:56 |
-| example.txt  | Yes            | 2021-05-10 16:03:56 | 2021-05-10 16:03:56 |
-| R/my\_mean.R | No             | NA                  | 2021-05-10 16:03:56 |
+| File        | Tracked in git | Date of creation    | Last modification   |
+|:------------|:---------------|:--------------------|:--------------------|
+| NEWS.md     | Yes            | 2022-03-04 16:31:14 | 2022-03-04 16:31:14 |
+| example.txt | Yes            | 2022-03-04 16:31:14 | 2022-03-04 16:31:14 |
+| R/my_mean.R | No             | NA                  | 2022-03-04 16:31:14 |
 
 ## Sponsor
 

--- a/dev_history.R
+++ b/dev_history.R
@@ -67,7 +67,7 @@ usethis::use_github_action("pkgdown")
 usethis::use_github_action("test-coverage")
 
 
-# CRAN
+# CRAN ----
 # Check content
 # remotes::install_github("ThinkR-open/checkhelper")
 checkhelper::find_missing_tags()

--- a/man/each_pattern.Rd
+++ b/man/each_pattern.Rd
@@ -34,7 +34,7 @@ repo <- fake_repo()
 res_commits <- nest_commits_by_pattern(
   repo,
   pattern = c("Tickets" = "ticket[[:digit:]]+"),
-  ref = "master", silent = TRUE
+  ref = "main", silent = TRUE
 )
 each_pattern(res_commits, "Tickets")
 }

--- a/man/get_commits_pattern.Rd
+++ b/man/get_commits_pattern.Rd
@@ -8,7 +8,7 @@ get_commits_pattern(
   repo = ".",
   pattern = c(Ticket = "#[[:digit:]]+"),
   pattern.table = NULL,
-  ref = "master",
+  ref = "main",
   path = NULL,
   silent = FALSE
 )

--- a/man/get_commits_tags.Rd
+++ b/man/get_commits_tags.Rd
@@ -4,7 +4,7 @@
 \alias{get_commits_tags}
 \title{Get commits associated chronologically with tags}
 \usage{
-get_commits_tags(repo = ".", ref = "master", path = NULL, silent = FALSE)
+get_commits_tags(repo = ".", ref = "main", path = NULL, silent = FALSE)
 }
 \arguments{
 \item{repo}{a path to a repository or a \code{git_repository}

--- a/man/git_down.Rd
+++ b/man/git_down.Rd
@@ -11,7 +11,7 @@ git_down(
   author = "John Doe",
   pattern = c(Issues = "#[[:digit:]]+"),
   pattern.table = NULL,
-  ref = "master",
+  ref = "main",
   ...
 )
 }
@@ -29,7 +29,7 @@ git_down(
 \item{pattern.table}{data.frame with two columns: pattern and description of the pattern.
 This is used as correspondence table to add some names to existing patterns.}
 
-\item{ref}{the name of the branch, by default master}
+\item{ref}{the name of the branch, by default main}
 
 \item{...}{Other parameters to pass to \code{\link[rmarkdown:render]{rmarkdown::render()}}}
 }

--- a/man/nest_commits_by_pattern.Rd
+++ b/man/nest_commits_by_pattern.Rd
@@ -8,7 +8,7 @@ nest_commits_by_pattern(
   repo,
   pattern = c(Issues = "#[[:digit:]]+"),
   pattern.table = NULL,
-  ref = "master",
+  ref = "main",
   silent = TRUE
 )
 }

--- a/tests/testthat/test-fake_repo.R
+++ b/tests/testthat/test-fake_repo.R
@@ -2,8 +2,12 @@ test_that("fake_repo works", {
   repo_input <- tempfile(pattern = "git2r-")
   repo_output <- fake_repo(repo_input)
 
+  branches <- git2r::branches(repo_output)
+
+  expect_false(is.null(branches[["main"]]))
+
   all_commits <- git2r::commits(
-    repo = repo_output, ref = "master",
+    repo = repo_output, ref = "main",
     topological = TRUE, time = TRUE, reverse = FALSE
   )
 

--- a/vignettes/ab-create-git_down.Rmd
+++ b/vignettes/ab-create-git_down.Rmd
@@ -59,14 +59,14 @@ As a side effect of {gitdown}, you can get some intermediate information used to
 - Find all commits of a branch and associate with tags recursively
 
 ```{r}
-get_commits_tags(repo, ref = "master")
+get_commits_tags(repo, ref = "main")
 ```
 
 - Find all commits of a branch and detect a specific pattern
     + Here we find commits mentioning an issue with `#123`
     
 ```{r}
-get_commits_pattern(repo, pattern = "#[[:digit:]]+", ref = "master")
+get_commits_pattern(repo, pattern = "#[[:digit:]]+", ref = "main")
 ```
 
 ## Create a vignette that lists all files with date of modification


### PR DESCRIPTION
When I checked the reverse dependencies for git2r, the gitdown package failed on my system since I've the following in `~/.gitconfig`
```
[init]
	defaultBranch = main
```
This change ensures that the branch name in the fake repo is master.